### PR TITLE
[#18] Parser defaults to returning 16 rows when a limit is not defined

### DIFF
--- a/api_plugin/src/server.cpp
+++ b/api_plugin/src/server.cpp
@@ -79,6 +79,7 @@ namespace
                     gq::options opts;
                     opts.username = _comm->clientUser.userName; // TODO Handle remote users?
                     opts.admin_mode = irods::is_privileged_client(*_comm);
+                    //opts.default_number_of_rows = 8; // TODO Can be pulled from the catalog on server startup.
                     const auto [sql, values] = gq::to_sql(ast, opts);
 
                     log_api::info("Returning to client: [{}]", sql);

--- a/parser/include/irods/genquery_sql.hpp
+++ b/parser/include/irods/genquery_sql.hpp
@@ -1,8 +1,6 @@
 #ifndef IRODS_GENQUERY_SQL_HPP
 #define IRODS_GENQUERY_SQL_HPP
 
-//#include "irods/genquery_ast_types.hpp"
-
 #include <string>
 #include <string_view>
 
@@ -14,6 +12,7 @@ namespace irods::experimental::api::genquery
     {
         std::string_view username;
         bool admin_mode = false;
+        std::uint16_t default_number_of_rows = 16;
     }; // struct options
 
     auto to_sql(const select& _select, const options& _opts) -> std::tuple<std::string, std::vector<std::string>>;

--- a/parser/src/genquery_sql.cpp
+++ b/parser/src/genquery_sql.cpp
@@ -1072,6 +1072,9 @@ namespace irods::experimental::api::genquery
             if (!_select.range.number_of_rows.empty()) {
                 sql += fmt::format(" fetch first {} rows only", _select.range.number_of_rows);
             }
+            else {
+                sql += fmt::format(" fetch first {} rows only", _opts.default_number_of_rows);
+            }
 
             std::for_each(std::begin(state.values), std::end(state.values), [](auto&& _j) {
                 log_gq::debug("BINDABLE VALUE => {}", _j);


### PR DESCRIPTION
This protects the server from out-of-memory errors.

If a client wants more rows to be returned, all they need to do is specify the number of rows in the query string.

The default can be overridden via the "options::default_number_of_rows". "options::default_number_of_rows" is an unsigned 16-bit integer.

The limit embedded in the query string supersedes the value defined in the "options" data type.