### PR TITLE
[#9] Parser uses correct type for CAST() when handling DATA_RESC_HIER

### DIFF
--- a/parser/include/irods/genquery_sql.hpp
+++ b/parser/include/irods/genquery_sql.hpp
@@ -11,8 +11,9 @@ namespace irods::experimental::api::genquery
     struct options
     {
         std::string_view username;
-        bool admin_mode = false;
+        std::string_view database;
         std::uint16_t default_number_of_rows = 16;
+        bool admin_mode = false;
     }; // struct options
 
     auto to_sql(const select& _select, const options& _opts) -> std::tuple<std::string, std::vector<std::string>>;


### PR DESCRIPTION
The API plugin passes a database hint to the parser so that the parser knows which target type to use for the DATA_RESC_HIER WITH-clause.

The API plugin uses the key defined in server_config.json at the following location:

    - /plugin_configuration/database/<key>

Where <key> will be one of the following:

    - postgres
    - mysql
    - oracle

For those situations where <key> does not match one of those values, the parser defaults to using the value tied to "postgres".

This commit also renames the CTE table to "cte_drh" to avoid any future table naming collisions.