### PR TITLE
[#40] Enables compilation against iRODS 4.2.11 and later

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
-cmake_minimum_required(VERSION 3.12.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.11.0 FATAL_ERROR)
 
 option(IRODS_ENABLE_430_COMPATIBILITY "Enables compatibility with iRODS 4.3.0." YES) # Default to YES for community.
+option(IRODS_ENABLE_42X_COMPATIBILITY "Enables compatibility with iRODS 4.2.X." NO)  # Default to NO for community.
+
+if (IRODS_ENABLE_430_COMPATIBILITY AND IRODS_ENABLE_42X_COMPATIBILITY)
+  message(FATAL_ERROR "IRODS_ENABLE_430_COMPATIBILITY and IRODS_ENABLE_42X_COMPATIBILITY options are incompatible.")
+endif()
 
 find_package(IRODS REQUIRED CONFIG)
 
@@ -9,8 +14,12 @@ set(IRODS_PLUGIN_VERSION "${IRODS_VERSION}.${IRODS_PLUGIN_REVISION}")
 
 set(IRODS_PACKAGE_REVISION "1")
 
-include(RequireOutOfSourceBuild)
-include(IrodsCXXCompiler)
+if (IRODS_ENABLE_42X_COMPATIBILITY)
+  set(CMAKE_CXX_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang++)
+else()
+  include(RequireOutOfSourceBuild)
+  include(IrodsCXXCompiler)
+endif()
 
 set(CMAKE_CXX_STANDARD ${IRODS_CXX_STANDARD})
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -46,7 +55,9 @@ if (NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 # FIXME Why can't these be closer to the things that use them?
-find_package(nlohmann_json "3.6.1" REQUIRED)
+if (NOT IRODS_ENABLE_42X_COMPATIBILITY)
+  find_package(nlohmann_json "3.6.1" REQUIRED)
+endif()
 find_package(Threads REQUIRED)
 find_package(OpenSSL REQUIRED COMPONENTS Crypto SSL)
 
@@ -63,8 +74,10 @@ add_subdirectory(api_plugin)
 add_subdirectory(rule_engine)
 add_subdirectory(client)
 
-include(IrodsCPackCommon)
-include(IrodsCPackPlatform)
+if (NOT IRODS_ENABLE_42X_COMPATIBILITY)
+  include(IrodsCPackCommon)
+  include(IrodsCPackPlatform)
+endif()
 
 set(IRODS_PACKAGE_NAME irods-experimental-api-plugin-genquery2)
 
@@ -77,7 +90,6 @@ set(CPACK_PACKAGE_VERSION ${IRODS_PLUGIN_VERSION})
 set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
 set(CPACK_COMPONENT_INCLUDE_TOPLEVEL_DIRECTORY OFF)
 set(CPACK_COMPONENTS_GROUPING IGNORE)
-#set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "The integrated Rule-Oriented Data System") # Defined by IrodsCPackCommon
 
 set(CPACK_DEB_COMPONENT_INSTALL OFF)
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS OFF)
@@ -108,10 +120,16 @@ set(CPACK_DEBIAN_PACKAGE_DEPENDS "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-ru
 set(CPACK_RPM_PACKAGE_NAME ${IRODS_PACKAGE_NAME})
 set(CPACK_RPM_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}")
 
-# Defined by IrodsCPackPlatform
-#if (NOT CPACK_GENERATOR)
-#  set(CPACK_GENERATOR ${IRODS_CPACK_GENERATOR} CACHE STRING "CPack generator to use, e.g. {DEB, RPM, TGZ}." FORCE)
-#  message(STATUS "Setting unspecified CPACK_GENERATOR to ${CPACK_GENERATOR}. This is the correct setting for normal builds.")
-#endif()
+if (IRODS_ENABLE_42X_COMPATIBILITY)
+  set(CPACK_PACKAGE_CONTACT "Renaissance Computing Institute <info@irods.org>")
+  set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "The integrated Rule-Oriented Data System") # Defined by IrodsCPackCommon.
+  set(CPACK_PACKAGE_VENDOR "Renaissance Computing Institute <info@irods.org>")
+
+  # Defined by IrodsCPackPlatform.
+  if (NOT CPACK_GENERATOR)
+    set(CPACK_GENERATOR ${IRODS_CPACK_GENERATOR} CACHE STRING "CPack generator to use, e.g. {DEB, RPM, TGZ}." FORCE)
+    message(STATUS "Setting unspecified CPACK_GENERATOR to ${CPACK_GENERATOR}. This is the correct setting for normal builds.")
+  endif()
+endif()
 
 include(CPack)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ If you're compiling this project against a later version of iRODS 4.3, then you'
 cmake -DIRODS_ENABLE_430_COMPATIBILITY=NO /path/to/git/repo
 ```
 
+This project can also be compiled for iRODS 4.2.11 and iRODS 4.2.12. To do that, run the following:
+```bash
+cmake -DIRODS_ENABLE_42X_COMPATIBILITY=YES -DIRODS_ENABLE_430_COMPATIBILITY=NO /path/to/git/repo
+```
+
 So far, this implementation has only run on Ubuntu 20.04 and Almalinux 8.
 
 ## Usage

--- a/api_plugin/CMakeLists.txt
+++ b/api_plugin/CMakeLists.txt
@@ -19,6 +19,16 @@ foreach (IRODS_MODULE_VARIANT IN ITEMS client server)
       ${IRODS_MODULE_NAME}
       PRIVATE
       IRODS_ENABLE_430_COMPATIBILITY)
+  elseif (IRODS_ENABLE_42X_COMPATIBILITY)
+    target_compile_definitions(
+      ${IRODS_MODULE_NAME}
+      PRIVATE
+      IRODS_ENABLE_42X_COMPATIBILITY)
+  
+    target_include_directories(
+      ${IRODS_MODULE_NAME}
+      PRIVATE
+  	  ${IRODS_EXTERNALS_FULLPATH_JSON}/include)
   endif()
 
   target_compile_definitions(

--- a/api_plugin/src/plugin_factory.cpp
+++ b/api_plugin/src/plugin_factory.cpp
@@ -2,9 +2,14 @@
 #include "irods/plugins/api/genquery2_common.h" // For API plugin number.
 
 #include <irods/apiHandler.hpp>
-#include <irods/client_api_allowlist.hpp>
 #include <irods/rcMisc.h>
 #include <irods/rodsPackInstruct.h>
+
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+#  include <irods/client_api_whitelist.hpp>
+#else
+#  include <irods/client_api_allowlist.hpp>
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 
 // The plugin factory function must always be defined.
 extern "C" auto plugin_factory(
@@ -14,11 +19,13 @@ extern "C" auto plugin_factory(
 #ifdef RODS_SERVER
 	// If your API endpoint is designed to be invocable by non-admins, then you need to
 	// add the API plugin number to the allowlist.
-#  ifdef IRODS_ENABLE_430_COMPATIBILITY
+#  if defined(IRODS_ENABLE_430_COMPATIBILITY)
 	irods::client_api_allowlist::instance().add(IRODS_APN_GENQUERY2);
+#  elif defined(IRODS_ENABLE_42X_COMPATIBILITY)
+	irods::client_api_whitelist::instance().add(IRODS_APN_GENQUERY2);
 #  else
 	irods::client_api_allowlist::add(IRODS_APN_GENQUERY2);
-#  endif // IRODS_ENABLE_430_COMPATIBILITY
+#  endif
 #endif // RODS_SERVER
 
 	// TODO We need to be able to add API plugin numbers to the API plugin number map.
@@ -35,7 +42,7 @@ extern "C" auto plugin_factory(
 		0,
 		op,
 		"api_genquery2",
-#ifdef IRODS_ENABLE_430_COMPATIBILITY
+#if defined(IRODS_ENABLE_430_COMPATIBILITY) || defined(IRODS_ENABLE_42X_COMPATIBILITY)
 		[](void* _p) {
 			auto* q = static_cast<genquery2_input*>(_p);
 			if (q->query_string) { std::free(q->query_string); }
@@ -48,7 +55,7 @@ extern "C" auto plugin_factory(
 			if (q->zone)         { std::free(q->zone); }
 		},
 		irods::clearOutStruct_noop, // TODO This blocks support for 4.2.
-#endif // IRODS_ENABLE_430_COMPATIBILITY
+#endif // defined(IRODS_ENABLE_430_COMPATIBILITY) || defined(IRODS_ENABLE_42X_COMPATIBILITY)
 		fn_ptr
 	};
 	// clang-format on

--- a/api_plugin/src/server.cpp
+++ b/api_plugin/src/server.cpp
@@ -16,8 +16,7 @@
 #  include <irods/rodsLog.h>
 #  include <json.hpp>
 #else
-#  include <irods/catalog.hpp>           // Requires linking against libnanodbc.so
-#  include <irods/catalog_utilities.hpp> // Requires linking against libnanodbc.so. Probably not needed.
+#  include <irods/catalog.hpp> // Requires linking against libnanodbc.so
 #  include <irods/irods_logger.hpp>
 #  include <nlohmann/json.hpp>
 #endif // IRODS_ENABLE_42X_COMPATIBILITY
@@ -79,21 +78,21 @@ namespace
 		if (_input->zone) {
 #ifdef IRODS_ENABLE_42X_COMPATIBILITY
 			rodsLog(LOG_DEBUG8,
-			        "GenQuery 2 API endpoint received: query_string=[%s], zone=[%s]",
+			        "GenQuery2 API endpoint received: query_string=[%s], zone=[%s]",
 			        _input->query_string,
 			        _input->zone);
 #else
 			log_api::trace(
-				"GenQuery 2 API endpoint received: query_string=[{}], zone=[{}]", _input->query_string, _input->zone);
+				"GenQuery2 API endpoint received: query_string=[{}], zone=[{}]", _input->query_string, _input->zone);
 #endif // IRODS_ENABLE_42X_COMPATIBILITY
 		}
 		else {
 #ifdef IRODS_ENABLE_42X_COMPATIBILITY
 			rodsLog(LOG_DEBUG8,
-			        "GenQuery 2 API endpoint received: query_string=[%s], zone=[nullptr]",
+			        "GenQuery2 API endpoint received: query_string=[%s], zone=[nullptr]",
 			        _input->query_string);
 #else
-			log_api::trace("GenQuery 2 API endpoint received: query_string=[{}], zone=[nullptr]", _input->query_string);
+			log_api::trace("GenQuery2 API endpoint received: query_string=[{}], zone=[nullptr]", _input->query_string);
 #endif // IRODS_ENABLE_42X_COMPATIBILITY
 		}
 

--- a/api_plugin/src/server.cpp
+++ b/api_plugin/src/server.cpp
@@ -88,9 +88,8 @@ namespace
 		}
 		else {
 #ifdef IRODS_ENABLE_42X_COMPATIBILITY
-			rodsLog(LOG_DEBUG8,
-			        "GenQuery2 API endpoint received: query_string=[%s], zone=[nullptr]",
-			        _input->query_string);
+			rodsLog(
+				LOG_DEBUG8, "GenQuery2 API endpoint received: query_string=[%s], zone=[nullptr]", _input->query_string);
 #else
 			log_api::trace("GenQuery2 API endpoint received: query_string=[{}], zone=[nullptr]", _input->query_string);
 #endif // IRODS_ENABLE_42X_COMPATIBILITY

--- a/api_plugin/src/server.cpp
+++ b/api_plugin/src/server.cpp
@@ -2,29 +2,39 @@
 #include "irods/plugins/api/genquery2_common.h" // For API plugin number.
 
 #include <irods/apiHandler.hpp>
-#include <irods/catalog.hpp>           // Requires linking against libnanodbc.so
-#include <irods/catalog_utilities.hpp> // Requires linking against libnanodbc.so
-#include <irods/irods_logger.hpp>
 #include <irods/irods_rs_comm_query.hpp>
-//#include <irods/irods_re_serialization.hpp> // For custom data types that can be used in the NREP.
 #include <irods/irods_server_properties.hpp>
 #include <irods/procApiRequest.h>
 #include <irods/rodsConnect.h>
 #include <irods/rodsDef.h>
 #include <irods/rodsErrorTable.h>
 
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+#  include <irods/irods_configuration_keywords.hpp>
+#  include <irods/irods_get_full_path_for_config_file.hpp>
+#  include <irods/irods_server_properties.hpp>
+#  include <irods/rodsLog.h>
+#  include <json.hpp>
+#else
+#  include <irods/catalog.hpp>           // Requires linking against libnanodbc.so
+#  include <irods/catalog_utilities.hpp> // Requires linking against libnanodbc.so. Probably not needed.
+#  include <irods/irods_logger.hpp>
+#  include <nlohmann/json.hpp>
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
+
 #include "irods/genquery2_driver.hpp"
 #include "irods/genquery2_sql.hpp"
 
 #include <fmt/format.h>
-#include <nlohmann/json.hpp>
 #include <nanodbc/nanodbc.h>
 
 #include <cstring> // For strdup.
 
 namespace
 {
+#ifndef IRODS_ENABLE_42X_COMPATIBILITY
 	using log_api = irods::experimental::log::api;
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 
 	//
 	// Function Prototypes
@@ -33,6 +43,13 @@ namespace
 	auto call_genquery2(irods::api_entry*, RsComm*, const genquery2_input*, char**) -> int;
 
 	auto rs_genquery2(RsComm*, const genquery2_input*, char**) -> int;
+
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+	// catalog.hpp and catalog_utilities.hpp are not included in the dev package, so copy
+	// the implementation of this function to ease compatibility between 4.2 and later versions
+	// of iRODS.
+	auto new_database_connection(bool _read_server_config = false) -> std::tuple<std::string, nanodbc::connection>;
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 
 	//
 	// Function Implementations
@@ -46,7 +63,11 @@ namespace
 	auto rs_genquery2(RsComm* _comm, const genquery2_input* _input, char** _output) -> int
 	{
 		if (!_input || !_input->query_string || !_output) {
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_ERROR, "Invalid input: received nullptr for message pointer and/or response pointer.");
+#else
 			log_api::error("Invalid input: received nullptr for message pointer and/or response pointer.");
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 			return SYS_INVALID_INPUT_PARAM;
 		}
 
@@ -56,19 +77,39 @@ namespace
 		// If the client did not provide a zone, getAndConnRcatHost() will operate as if the
 		// client provided the local zone's name.
 		if (_input->zone) {
-			log_api::info(
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_DEBUG8,
+			        "GenQuery 2 API endpoint received: query_string=[%s], zone=[%s]",
+			        _input->query_string,
+			        _input->zone);
+#else
+			log_api::trace(
 				"GenQuery 2 API endpoint received: query_string=[{}], zone=[{}]", _input->query_string, _input->zone);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 		}
 		else {
-			log_api::info("GenQuery 2 API endpoint received: query_string=[{}], zone=[nullptr]", _input->query_string);
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_DEBUG8,
+			        "GenQuery 2 API endpoint received: query_string=[%s], zone=[nullptr]",
+			        _input->query_string);
+#else
+			log_api::trace("GenQuery 2 API endpoint received: query_string=[{}], zone=[nullptr]", _input->query_string);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 		}
 
 		rodsServerHost* host_info{};
 
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+		if (const auto ec = getAndConnRcatHost(_comm, MASTER_RCAT, _input->zone, &host_info); ec < 0) {
+			rodsLog(LOG_ERROR, "Could not connect to remote zone [%s].", _input->zone);
+			return ec;
+		}
+#else
 		if (const auto ec = getAndConnRcatHost(_comm, PRIMARY_RCAT, _input->zone, &host_info); ec < 0) {
 			log_api::error("Could not connect to remote zone [{}].", _input->zone);
 			return ec;
 		}
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 
 		// Return an error if the host information does not point to the zone of interest.
 		// getAndConnRcatHost() returns the local zone if the target zone does not exist. We must catch
@@ -77,18 +118,30 @@ namespace
 			const std::string_view resolved_zone = static_cast<zoneInfo*>(host_info->zoneInfo)->zoneName;
 
 			if (resolved_zone != _input->zone) {
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+				rodsLog(LOG_ERROR, "Could not find zone [%s].", _input->zone);
+#else
 				log_api::error("Could not find zone [{}].", _input->zone);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 				return SYS_INVALID_ZONE_NAME;
 			}
 		}
 
 		if (host_info->localFlag != LOCAL_HOST) {
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_DEBUG8, "Redirecting request to remote zone [%s].", _input->zone);
+#else
 			log_api::trace("Redirecting request to remote zone [{}].", _input->zone);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 
 			return procApiRequest(
 				host_info->conn,
 				IRODS_APN_GENQUERY2,
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+				const_cast<genquery2_input*>(_input),
+#else
 				_input,
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 				nullptr,
 				reinterpret_cast<void**>(_output), // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 				nullptr);
@@ -105,14 +158,27 @@ namespace
 
 			{
 				// Get the database type string from server_config.json.
-#ifdef IRODS_ENABLE_430_COMPATIBILITY
-				const auto& config = irods::server_properties::instance().map();
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+				// clang-format off
+				using map_type      = std::unordered_map<std::string, boost::any>;
+				using key_path_type = irods::configuration_parser::key_path_t;
+				// clang-format on
+
+				const auto& db_plugin_config = irods::get_server_property<const map_type&>(
+					key_path_type{irods::CFG_PLUGIN_CONFIGURATION_KW, irods::PLUGIN_TYPE_DATABASE});
+				const auto& [key, value] = *std::begin(db_plugin_config);
+
+				opts.database = key;
 #else
+#  ifdef IRODS_ENABLE_430_COMPATIBILITY
+				const auto& config = irods::server_properties::instance().map();
+#  else
 				const auto handle = irods::server_properties::instance().map();
 				const auto& config = handle.get_json();
-#endif
+#  endif // IRODS_ENABLE_430_COMPATIBILITY
 				const auto& db = config.at(json::json_pointer{"/plugin_configuration/database"});
 				opts.database = std::begin(db).key();
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 			}
 
 			opts.username = _comm->clientUser.userName; // TODO Handle remote users?
@@ -122,13 +188,21 @@ namespace
 			irods::experimental::genquery2::driver driver;
 
 			if (const auto ec = driver.parse(_input->query_string); ec != 0) {
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+				rodsLog(LOG_ERROR, "Failed to parse GenQuery2 string. [error code=[%d]]", ec);
+#else
 				log_api::error("Failed to parse GenQuery2 string. [error code=[{}]]", ec);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 				return SYS_LIBRARY_ERROR;
 			}
 
 			const auto [sql, values] = gq::to_sql(driver.select, opts);
 
-			log_api::info("Returning to client: [{}]", sql);
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_DEBUG8, "Returning to client: [%s]", sql.c_str());
+#else
+			log_api::trace("Returning to client: [{}]", sql);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 
 			if (1 == _input->sql_only) {
 				*_output = strdup(sql.c_str());
@@ -136,11 +210,19 @@ namespace
 			}
 
 			if (sql.empty()) {
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+				rodsLog(LOG_ERROR, "Could not generate SQL from GenQuery.");
+#else
 				log_api::error("Could not generate SQL from GenQuery.");
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 				return SYS_INVALID_INPUT_PARAM;
 			}
 
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			auto [db_inst, db_conn] = new_database_connection();
+#else
 			auto [db_inst, db_conn] = irods::experimental::catalog::new_database_connection();
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 
 			nanodbc::statement stmt{db_conn};
 			nanodbc::prepare(stmt, sql);
@@ -156,7 +238,7 @@ namespace
 			const auto n_cols = row.columns();
 
 			while (row.next()) {
-				for (std::remove_cvref_t<decltype(n_cols)> i = 0; i < n_cols; ++i) {
+				for (std::remove_const_t<decltype(n_cols)> i = 0; i < n_cols; ++i) {
 					json_row.push_back(row.get<std::string>(i, ""));
 				}
 
@@ -167,16 +249,109 @@ namespace
 			*_output = strdup(json_array.dump().c_str());
 		}
 		catch (const nanodbc::database_error& e) {
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_ERROR, "Caught database exception while executing query: %s", e.what());
+#else
 			log_api::error("Caught database exception while executing query: {}", e.what());
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 			return SYS_LIBRARY_ERROR;
 		}
 		catch (const std::exception& e) {
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_ERROR, "Caught exception while executing query: %s", e.what());
+#else
 			log_api::error("Caught exception while executing query: {}", e.what());
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 			return SYS_LIBRARY_ERROR;
 		}
 
 		return 0;
 	} // rs_genquery2
+
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+	auto new_database_connection(bool _read_server_config) -> std::tuple<std::string, nanodbc::connection>
+	{
+		const std::string dsn = [] {
+			if (const char* dsn = std::getenv("irodsOdbcDSN"); dsn) {
+				return dsn;
+			}
+
+			return "iRODS Catalog";
+		}();
+
+		std::string db_username;
+		std::string db_password;
+		std::string db_instance_name;
+
+		if (_read_server_config) {
+			std::string config_path;
+
+			if (const auto error = irods::get_full_path_for_config_file("server_config.json", config_path); !error.ok())
+			{
+				rodsLog(LOG_ERROR, "Server configuration not found");
+				throw std::runtime_error{"Failed to connect to catalog"};
+			}
+
+			rodsLog(LOG_DEBUG9, "Reading server configuration ...");
+
+			nlohmann::json config;
+
+			{
+				std::ifstream config_file{config_path};
+				config_file >> config;
+			}
+
+			const auto& db_plugin_config =
+				config.at(irods::CFG_PLUGIN_CONFIGURATION_KW).at(irods::PLUGIN_TYPE_DATABASE);
+			const auto& db_instance = db_plugin_config.front();
+
+			db_instance_name = std::begin(db_plugin_config).key();
+			db_username = db_instance.at(irods::CFG_DB_USERNAME_KW).get<std::string>();
+			db_password = db_instance.at(irods::CFG_DB_PASSWORD_KW).get<std::string>();
+		}
+		else {
+			// clang-format off
+			using map_type      = std::unordered_map<std::string, boost::any>;
+			using key_path_type = irods::configuration_parser::key_path_t;
+			// clang-format on
+
+			const auto& db_plugin_config = irods::get_server_property<const map_type&>(
+				key_path_type{irods::CFG_PLUGIN_CONFIGURATION_KW, irods::PLUGIN_TYPE_DATABASE});
+			const auto& [key, value] = *std::begin(db_plugin_config);
+			const auto& db_instance = boost::any_cast<const map_type&>(value);
+
+			db_instance_name = key;
+			db_username = boost::any_cast<const std::string&>(db_instance.at(irods::CFG_DB_USERNAME_KW));
+			db_password = boost::any_cast<const std::string&>(db_instance.at(irods::CFG_DB_PASSWORD_KW));
+		}
+
+		try {
+			if (db_instance_name.empty()) {
+				throw std::runtime_error{"Database instance name cannot be empty"};
+			}
+
+			rodsLog(LOG_DEBUG9, fmt::format("attempting connection to database using dsn [{}]", dsn).c_str());
+
+			nanodbc::connection db_conn{dsn, db_username, db_password};
+
+			if (db_instance_name == "mysql") {
+				// MySQL must be running in ANSI mode (or at least in PIPES_AS_CONCAT mode) to be
+				// able to understand Postgres SQL. STRICT_TRANS_TABLES must be set too, otherwise
+				// inserting NULL into a "NOT NULL" column does not produce an error.
+				nanodbc::just_execute(db_conn, "set SESSION sql_mode = 'ANSI,STRICT_TRANS_TABLES'");
+				nanodbc::just_execute(db_conn, "set character_set_client = utf8");
+				nanodbc::just_execute(db_conn, "set character_set_results = utf8");
+				nanodbc::just_execute(db_conn, "set character_set_connection = utf8");
+			}
+
+			return {db_instance_name, db_conn};
+		}
+		catch (const std::exception& e) {
+			rodsLog(LOG_ERROR, e.what());
+			throw std::runtime_error{"Failed to connect to catalog"};
+		}
+	} // new_database_connection
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 } //namespace
 
 const operation_type op = rs_genquery2;

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(
 target_compile_definitions(
   ${IRODS_EXECUTABLE_NAME}
   PRIVATE
-  #${IRODS_COMPILE_DEFINITIONS}
+  #${IRODS_COMPILE_DEFINITIONS} # TODO Is this needed?
   ${IRODS_COMPILE_DEFINITIONS_PRIVATE})
 
 target_include_directories(
@@ -24,6 +24,23 @@ target_link_libraries(
   irods_client
   ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_program_options.so
   ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so)
+
+if (IRODS_ENABLE_42X_COMPATIBILITY)
+  target_compile_definitions(
+    ${IRODS_EXECUTABLE_NAME}
+    PRIVATE
+    IRODS_ENABLE_42X_COMPATIBILITY)
+
+  target_include_directories(
+    ${IRODS_EXECUTABLE_NAME}
+    PRIVATE
+    ${IRODS_EXTERNALS_FULLPATH_JSON}/include)
+
+  target_link_libraries(
+    ${IRODS_EXECUTABLE_NAME}
+    PRIVATE
+	irods_common) # For irods::exception.
+endif()
 
 add_dependencies(${IRODS_EXECUTABLE_NAME} irods_genquery2_client)
 

--- a/client/src/main.cpp
+++ b/client/src/main.cpp
@@ -15,7 +15,11 @@ auto print_usage_info() -> void;
 
 int main(int _argc, char* _argv[]) // NOLINT(modernize-use-trailing-return-type)
 {
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+	setenv(SP_OPTION, "iquery (experimental)", /* overwrite */ 1);
+#else
 	set_ips_display_name("iquery (experimental)");
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 
 	namespace po = boost::program_options;
 
@@ -80,7 +84,11 @@ int main(int _argc, char* _argv[]) // NOLINT(modernize-use-trailing-return-type)
 			return 1;
 		}
 
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+		(1 == input.sql_only) ? fmt::print("{}\n", sql) : fmt::print(sql);
+#else
 		(1 == input.sql_only) ? fmt::print("{}\n", sql) : fmt::print(fmt::runtime(sql));
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 
 		std::free(sql);
 

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -28,6 +28,11 @@ if (IRODS_ENABLE_430_COMPATIBILITY)
     ${IRODS_PARSER_NAME}
     PRIVATE
     IRODS_ENABLE_430_COMPATIBILITY)
+elseif (IRODS_ENABLE_42X_COMPATIBILITY)
+  target_compile_definitions(
+    ${IRODS_PARSER_NAME}
+    PRIVATE
+    IRODS_ENABLE_42X_COMPATIBILITY)
 endif()
 
 target_compile_definitions(
@@ -47,10 +52,14 @@ target_include_directories(
   ${IRODS_EXTERNALS_FULLPATH_JSON}/include # TODO Should this be nlohmann_json::nlohmann_json?
   ${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include)
 
-target_link_libraries(
-  ${IRODS_PARSER_NAME}
-  PRIVATE
-  #${FLEX_LIBRARIES} # This causes a compiler error when using C++ (i.e. undefined reference to yylex()).
-  irods_server
-  ${IRODS_EXTERNALS_FULLPATH_CLANG_RUNTIME}/lib/libc++.so
-  ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so)
+# TODO Perhaps this block isn't needed at all because we're generating an object file?
+# The conditional allows the code to compile for 4.2.11 for some reason. 4.3 isn't affected by this. Why?
+if (NOT IRODS_ENABLE_42X_COMPATIBILITY)
+  target_link_libraries(
+    ${IRODS_PARSER_NAME}
+    PRIVATE
+    #${FLEX_LIBRARIES} # This causes a compiler error when using C++ (i.e. undefined reference to yylex()).
+    irods_server
+    ${IRODS_EXTERNALS_FULLPATH_CLANG_RUNTIME}/lib/libc++.so
+    ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so)
+endif()

--- a/parser/src/genquery2_driver.cpp
+++ b/parser/src/genquery2_driver.cpp
@@ -11,6 +11,7 @@ namespace irods::experimental::genquery2
 		std::istringstream iss{_s};
 		lexer.switch_streams(&iss);
 
-		return yy::parser{*this}();
+		yy::parser p{*this};
+		return p.parse();
 	} // driver::parse
 } // namespace irods::experimental::genquery2

--- a/rule_engine/CMakeLists.txt
+++ b/rule_engine/CMakeLists.txt
@@ -35,11 +35,32 @@ target_link_libraries(
   ${IRODS_RULE_ENGINE_PLUGIN_NAME}
   PRIVATE
   irods_server
-  nlohmann_json::nlohmann_json
   ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_filesystem.so
   ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so
   ${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so
   dl)
+
+if (IRODS_ENABLE_42X_COMPATIBILITY)
+  target_compile_definitions(
+    ${IRODS_RULE_ENGINE_PLUGIN_NAME}
+    PRIVATE
+    IRODS_ENABLE_42X_COMPATIBILITY)
+
+  target_include_directories(
+    ${IRODS_RULE_ENGINE_PLUGIN_NAME}
+    PRIVATE
+    ${IRODS_EXTERNALS_FULLPATH_JSON}/include)
+
+  target_link_libraries(
+    ${IRODS_RULE_ENGINE_PLUGIN_NAME}
+    PRIVATE
+	irods_common) # For rodsLog, etc.
+else()
+  target_link_libraries(
+    ${IRODS_RULE_ENGINE_PLUGIN_NAME}
+    PRIVATE
+    nlohmann_json::nlohmann_json)
+endif()
 
 install(
   TARGETS ${IRODS_RULE_ENGINE_PLUGIN_NAME}

--- a/rule_engine/src/main.cpp
+++ b/rule_engine/src/main.cpp
@@ -2,16 +2,22 @@
 #include "irods/plugins/api/genquery2_common.h"
 
 #include <irods/irods_at_scope_exit.hpp>
-#include <irods/irods_logger.hpp>
 #include <irods/irods_plugin_context.hpp>
 #include <irods/irods_re_plugin.hpp>
 #include <irods/irods_state_table.h>
 #include <irods/rodsError.h>
 #include <irods/rodsErrorTable.h>
 
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+#  include <irods/rodsLog.h>
+#  include <json.hpp>
+#else
+#  include <irods/irods_logger.hpp>
+#  include <nlohmann/json.hpp>
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
+
 #include <fmt/format.h>
 #include <boost/any.hpp>
-#include <nlohmann/json.hpp>
 
 #include <algorithm>
 #include <cstdint>
@@ -26,7 +32,9 @@
 namespace
 {
 	// clang-format off
-	using log_rule_engine = irods::experimental::log::rule_engine;
+#ifndef IRODS_ENABLE_42X_COMPATIBILITY
+	using log_re = irods::experimental::log::rule_engine;
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 	using handler_type    = std::function<irods::error(std::list<boost::any>&, irods::callback&)>;
 	// clang-format on
 
@@ -52,13 +60,22 @@ namespace
 
 	auto genquery2_execute(std::list<boost::any>& _rule_arguments, irods::callback& _effect_handler) -> irods::error
 	{
-		log_rule_engine::info(__func__);
-		log_rule_engine::info("number of arguments = [{}]", _rule_arguments.size());
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+		rodsLog(LOG_DEBUG8, __func__);
+		rodsLog(LOG_DEBUG8, fmt::format("Number of arguments = [{}]", _rule_arguments.size()).c_str());
+#else
+		log_re::trace(__func__);
+		log_re::debug("Number of arguments = [{}]", _rule_arguments.size());
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 
 		if (_rule_arguments.size() != 2) {
 			const auto msg =
 				fmt::format("Incorrect number of input arguments: expected 2, received {}", _rule_arguments.size());
-			log_rule_engine::info(msg);
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_ERROR, msg.c_str());
+#else
+			log_re::error(msg);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 			return ERROR(SYS_INVALID_INPUT_PARAM, msg);
 		}
 
@@ -75,7 +92,11 @@ namespace
 
 			if (const auto ec = irods::server_api_call(IRODS_APN_GENQUERY2, rei.rsComm, &input, &results); ec != 0) {
 				const auto msg = fmt::format("Error while executing GenQuery 2 query [error_code=[{}]].", ec);
-				log_rule_engine::error(msg);
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+				rodsLog(LOG_ERROR, msg.c_str());
+#else
+				log_re::error(msg);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 				return ERROR(ec, msg);
 			}
 
@@ -88,23 +109,39 @@ namespace
 			return SUCCESS();
 		}
 		catch (const irods::exception& e) {
-			log_rule_engine::error(e.client_display_what());
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_ERROR, e.client_display_what());
+#else
+			log_re::error(e.client_display_what());
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 			return ERROR(e.code(), e.client_display_what());
 		}
 		catch (const std::exception& e) {
-			log_rule_engine::error(e.what());
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_ERROR, e.what());
+#else
+			log_re::error(e.what());
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 			return ERROR(SYS_LIBRARY_ERROR, e.what());
 		}
 	} // genquery2_execute
 
 	auto genquery2_next_row(std::list<boost::any>& _rule_arguments, irods::callback&) -> irods::error
 	{
-		log_rule_engine::info(__func__);
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+		rodsLog(LOG_DEBUG8, __func__);
+#else
+		log_re::trace(__func__);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 
 		if (_rule_arguments.size() != 1) {
 			const auto msg =
 				fmt::format("Incorrect number of input arguments: expected 1, received {}", _rule_arguments.size());
-			log_rule_engine::info(msg);
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_ERROR, msg.c_str());
+#else
+			log_re::error(msg);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 			return ERROR(SYS_INVALID_INPUT_PARAM, msg);
 		}
 
@@ -115,7 +152,11 @@ namespace
 			if (ctx_handle_index < 0 ||
 			    static_cast<decltype(gq2_context)::size_type>(ctx_handle_index) >= gq2_context.size()) {
 				constexpr const auto* msg = "Unknown context handle.";
-				log_rule_engine::info(msg);
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+				rodsLog(LOG_ERROR, msg);
+#else
+				log_re::error(msg);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 				return ERROR(SYS_INVALID_INPUT_PARAM, msg);
 			}
 
@@ -123,13 +164,22 @@ namespace
 
 			if (ctx.current_row < static_cast<std::int32_t>(ctx.rows.size()) - 1) {
 				++ctx.current_row;
-				log_rule_engine::info(
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+				const auto msg = fmt::format(
 					"Incremented row position [{} => {}]. Returning 0.", ctx.current_row - 1, ctx.current_row);
+				rodsLog(LOG_DEBUG8, msg.c_str());
+#else
+				log_re::trace(
+					"Incremented row position [{} => {}]. Returning 0.", ctx.current_row - 1, ctx.current_row);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 				return CODE(0);
 			}
 
-			log_rule_engine::info(
-				"Skipping incrementing of row position [current_row=[{}]]. Returning 1.", ctx.current_row);
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_DEBUG8, "Skipping increment of row position [current_row=[%d]]. Returning 1.", ctx.current_row);
+#else
+			log_re::trace("Skipping increment of row position [current_row=[{}]]. Returning 1.", ctx.current_row);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 
 			// We must return ERROR(stop_code, "") to trigger correct usage of genquery2_next_row().
 			// Otherwise, the NREP can loop forever. Ultimately, this means we aren't allowed to return
@@ -137,11 +187,19 @@ namespace
 			return ERROR(1, "");
 		}
 		catch (const irods::exception& e) {
-			log_rule_engine::error(e.client_display_what());
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_ERROR, e.client_display_what());
+#else
+			log_re::error(e.client_display_what());
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 			return ERROR(e.code(), e.client_display_what());
 		}
 		catch (const std::exception& e) {
-			log_rule_engine::error(e.what());
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_ERROR, e.what());
+#else
+			log_re::error(e.what());
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 			return ERROR(SYS_LIBRARY_ERROR, e.what());
 		}
 
@@ -150,12 +208,20 @@ namespace
 
 	auto genquery2_column(std::list<boost::any>& _rule_arguments, irods::callback&) -> irods::error
 	{
-		log_rule_engine::info(__func__);
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+		rodsLog(LOG_DEBUG8, __func__);
+#else
+		log_re::trace(__func__);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 
 		if (_rule_arguments.size() != 3) {
 			const auto msg =
 				fmt::format("Incorrect number of input arguments: expected 3, received {}", _rule_arguments.size());
-			log_rule_engine::info(msg);
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_ERROR, msg.c_str());
+#else
+			log_re::error(msg);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 			return ERROR(SYS_INVALID_INPUT_PARAM, msg);
 		}
 
@@ -167,7 +233,11 @@ namespace
 			if (ctx_handle_index < 0 ||
 			    static_cast<decltype(gq2_context)::size_type>(ctx_handle_index) >= gq2_context.size()) {
 				constexpr const auto* msg = "Unknown context handle.";
-				log_rule_engine::info(msg);
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+				rodsLog(LOG_ERROR, msg);
+#else
+				log_re::error(msg);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 				return ERROR(SYS_INVALID_INPUT_PARAM, msg);
 			}
 
@@ -176,7 +246,11 @@ namespace
 			const auto column_index = std::stoll(*boost::any_cast<std::string*>(*iter));
 
 			const auto& value = ctx.rows.at(ctx.current_row).at(column_index).get_ref<const std::string&>();
-			log_rule_engine::info("Column value = [{}]", value);
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_DEBUG, "Column value = [%s]", value.c_str());
+#else
+			log_re::debug("Column value = [{}]", value);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 			iter = std::next(iter);
 			*boost::any_cast<std::string*>(*iter) =
 				ctx.rows.at(ctx.current_row).at(column_index).get_ref<const std::string&>();
@@ -184,11 +258,19 @@ namespace
 			return SUCCESS();
 		}
 		catch (const irods::exception& e) {
-			log_rule_engine::error(e.client_display_what());
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_ERROR, e.client_display_what());
+#else
+			log_re::error(e.client_display_what());
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 			return ERROR(e.code(), e.client_display_what());
 		}
 		catch (const std::exception& e) {
-			log_rule_engine::error(e.what());
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_ERROR, e.what());
+#else
+			log_re::error(e.what());
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 			return ERROR(SYS_LIBRARY_ERROR, e.what());
 		}
 
@@ -197,25 +279,41 @@ namespace
 
 	auto genquery2_destroy(std::list<boost::any>& _rule_arguments, irods::callback&) -> irods::error
 	{
-		log_rule_engine::info(__func__);
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+		rodsLog(LOG_DEBUG8, __func__);
+#else
+		log_re::trace(__func__);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 
 		if (_rule_arguments.size() != 1) {
 			const auto msg =
 				fmt::format("Incorrect number of input arguments: expected 1, received {}", _rule_arguments.size());
-			log_rule_engine::info(msg);
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_ERROR, msg.c_str());
+#else
+			log_re::error(msg);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 			return ERROR(SYS_INVALID_INPUT_PARAM, msg);
 		}
 
 		try {
 			auto iter = std::begin(_rule_arguments);
 			const auto* ctx_handle = boost::any_cast<std::string*>(*iter);
-			log_rule_engine::info("ctx_handle = [{}]", *ctx_handle); // FIXME It's empty in the PREP! :-(
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_DEBUG8, "ctx_handle = [%s]", ctx_handle->c_str());
+#else
+			log_re::trace("ctx_handle = [{}]", *ctx_handle);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 			const auto ctx_handle_index = std::stoll(*ctx_handle);
 
 			if (ctx_handle_index < 0 ||
 			    static_cast<decltype(gq2_context)::size_type>(ctx_handle_index) >= gq2_context.size()) {
 				constexpr const auto* msg = "Unknown context handle.";
-				log_rule_engine::info(msg);
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+				rodsLog(LOG_ERROR, msg);
+#else
+				log_re::error(msg);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 				return ERROR(SYS_INVALID_INPUT_PARAM, msg);
 			}
 
@@ -226,11 +324,19 @@ namespace
 			return SUCCESS();
 		}
 		catch (const irods::exception& e) {
-			log_rule_engine::error(e.client_display_what());
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_ERROR, e.client_display_what());
+#else
+			log_re::error(e.client_display_what());
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 			return ERROR(e.code(), e.client_display_what());
 		}
 		catch (const std::exception& e) {
-			log_rule_engine::error(e.what());
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_ERROR, e.what());
+#else
+			log_re::error(e.what());
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
 			return ERROR(SYS_LIBRARY_ERROR, e.what());
 		}
 
@@ -283,7 +389,12 @@ namespace
 	               std::list<boost::any>& _rule_arguments,
 	               irods::callback _effect_handler) -> irods::error
 	{
-		log_rule_engine::info(__func__);
+#ifdef IRODS_ENABLE_42X_COMPATIBILITY
+		rodsLog(LOG_DEBUG8, __func__);
+#else
+		log_re::trace(__func__);
+#endif // IRODS_ENABLE_42X_COMPATIBILITY
+
 		if (const auto iter = handlers.find(_rule_name); iter != std::end(handlers)) {
 			return (iter->second)(_rule_arguments, _effect_handler);
 		}
@@ -296,7 +407,11 @@ namespace
 	                         MsParamArray* _ms_param_array,
 	                         irods::callback _effect_handler) -> irods::error
 	{
-		log_rule_engine::debug("_rule_text = [{}]", _rule_text);
+#  ifdef IRODS_ENABLE_42X_COMPATIBILITY
+		rodsLog(LOG_DEBUG, "_rule_text = [%s]", std::string{_rule_text}.c_str());
+#  else
+		log_re::debug("_rule_text = [{}]", _rule_text);
+#  endif // IRODS_ENABLE_42X_COMPATIBILITY
 
 		// irule <text>
 		if (_rule_text.find("@external rule {") != std::string::npos) {
@@ -309,7 +424,11 @@ namespace
 			_rule_text = _rule_text.substr(start, _rule_text.rfind(" }") - start);
 		}
 
-		log_rule_engine::info("_rule_text = [{}]", std::string{_rule_text});
+#  ifdef IRODS_ENABLE_42X_COMPATIBILITY
+		rodsLog(LOG_DEBUG, "_rule_text = [%s]", std::string{_rule_text}.c_str());
+#  else
+		log_re::debug("_rule_text = [{}]", std::string{_rule_text});
+#  endif // IRODS_ENABLE_42X_COMPATIBILITY
 
 		/*
 		    {
@@ -362,7 +481,11 @@ namespace
 			return ERROR(INVALID_OPERATION, fmt::format("Invalid operation [{}]", op));
 		}
 		catch (const json::exception& e) {
-			log_rule_engine::error(e.what());
+#  ifdef IRODS_ENABLE_42X_COMPATIBILITY
+			rodsLog(LOG_ERROR, e.what());
+#  else
+			log_re::error(e.what());
+#  endif // IRODS_ENABLE_42X_COMPATIBILITY
 			return ERROR(SYS_INVALID_INPUT_PARAM, fmt::format("Could not parse rule text into JSON object"));
 		}
 	}  // exec_rule_text_impl

--- a/rule_engine/src/main.cpp
+++ b/rule_engine/src/main.cpp
@@ -91,7 +91,7 @@ namespace
 			char* results{};
 
 			if (const auto ec = irods::server_api_call(IRODS_APN_GENQUERY2, rei.rsComm, &input, &results); ec != 0) {
-				const auto msg = fmt::format("Error while executing GenQuery 2 query [error_code=[{}]].", ec);
+				const auto msg = fmt::format("Error while executing GenQuery2 query [error_code=[{}]].", ec);
 #ifdef IRODS_ENABLE_42X_COMPATIBILITY
 				rodsLog(LOG_ERROR, msg.c_str());
 #else


### PR DESCRIPTION
I've seen this PR compile and run (i.e. `iquery`) against iRODS 4.2.11 on Ubuntu 18 / PostgreSQL.

Once I've verified the REP works, we can decide on whether we want to merge this or create a separate branch for it. **The majority of the 4.2 changes will be dropped when this becomes part of the server.**

Most of the changes are logger-based. The rest are about handling missing and/or incompatibilities between 4.2 and 4.3.

I still need to do the following ...
- [x] Run clang-format on the changes
- [x] Compiles against iRODS 4.2.11
- [x] Compiles against iRODS 4.2.12
- [x] Compiles against iRODS 4.3.0
- [x] Compiles against iRODS 4-3-stable/main