### PR TITLE
[#51] Added support for escaping single quotes (main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,3 +368,7 @@ def list_all_data_objects(rule_args, callback, rei):
                                                                                             
     callback.genquery2_destroy(handle)
 ```
+
+### How do I embed single quotes within a string literal?
+
+To embed a single quote character within a string literal, write two adjacent single quotes. For example, `'What''s the current time?'`.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Once stable, the code will be merged into the iRODS server making it available w
 
 This project provides an API Plugin, a Rule Engine Plugin, and an iCommand upon successfully compiling it.
 
-This project only compiles against iRODS 4.3.0 and depends on the following:
+### Dependencies
 - irods-dev(el)
 - irods-runtime
 - irods-externals-boost

--- a/parser/dsl/lexer.l
+++ b/parser/dsl/lexer.l
@@ -18,6 +18,8 @@
     #define YY_USER_ACTION loc.columns(yyleng);
 %}
 
+%x ss_string_literal
+
 %%
 
 %{
@@ -26,10 +28,19 @@
 
     // Code run each time yylex() is called.
     loc.step();
+
+    // A handy shortcut to the object used for capturing string literals.
+    auto& string_literal = drv.string_literal;
 %}
 
+'                      { BEGIN(ss_string_literal); string_literal.clear(); }
+<ss_string_literal>{
+    "''"               { string_literal += '\''; }
+    '                  { BEGIN(INITIAL); return yy::parser::make_STRING_LITERAL(string_literal, loc); }
+    .                  { string_literal.append(1, *yytext); }
+    <<EOF>>            { throw yy::parser::syntax_error{loc, fmt::format("missing closing single quote: [{}]", string_literal)}; }
+}
 [ \t\n]                ;
-'(''|[^'])*'           { yytext[yyleng - 1] = '\0'; ++yytext; return yy::parser::make_STRING_LITERAL(yytext, loc); }
 (?i:select)            return yy::parser::make_SELECT(loc);
 (?i:where)             return yy::parser::make_WHERE(loc);
 (?i:like)              return yy::parser::make_LIKE(loc);

--- a/parser/dsl/parser.y
+++ b/parser/dsl/parser.y
@@ -239,7 +239,7 @@ list_of_identifiers:
 
 auto yy::parser::error(const yy::location& _loc, const std::string& _msg) -> void
 {
-    throw std::invalid_argument{fmt::format("{} @ {}", _msg, _loc.begin.column)};
+    throw std::invalid_argument{fmt::format("{} at position {}", _msg, _loc.begin.column)};
 } // gq::parser::error
 
 auto yylex(irods::experimental::genquery2::driver& drv) -> yy::parser::symbol_type

--- a/parser/include/irods/genquery2_driver.hpp
+++ b/parser/include/irods/genquery2_driver.hpp
@@ -30,6 +30,10 @@ namespace irods::experimental::genquery2
 		irods::experimental::api::genquery::select select;
 		scanner lexer;
 		yy::location location;
+
+		// Used by the lexer to capture string literals.
+		// This aids in handling escape sequences.
+		std::string string_literal;
 	}; // class driver
 } // namespace irods::experimental::genquery2
 

--- a/parser/include/irods/genquery2_driver.hpp
+++ b/parser/include/irods/genquery2_driver.hpp
@@ -27,8 +27,13 @@ namespace irods::experimental::genquery2
 
 		auto parse(const std::string& _s) -> int;
 
+		// Holds an AST-like representation of a GenQuery2 string.
 		irods::experimental::api::genquery::select select;
+
+		// The Flex scanner implementation.
 		scanner lexer;
+
+		// Holds the current location of the parser.
 		yy::location location;
 
 		// Used by the lexer to capture string literals.


### PR DESCRIPTION
The changes in this PR allow certain characters to be accepted by the GenQuery2 parser by escaping them.

For example, this PR allows `[]{}()#!@$^&,;'%^.txt` to be accepted by simply escaping it in the following way:
```
[]{}()#\!@$^&,;\'%^.txt
```
Or
```
[]{}()#\!@$^&,;''%^.txt
```

I've verified the code works.

However, I'm going to try a different approach to see how that plays out before merging this.