### PR TITLE
[#51] Parser now supports hexadecimal escape sequences (main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Once stable, the code will be merged into the iRODS server making it available w
 - Operators: =, !=, <, <=, >, >=, LIKE, BETWEEN, IS [NOT] NULL
 - SQL keywords are case-insensitive
 - Federation is supported
+- Escaping of single quotes
+- Bytes encoded as hexadecimal
 
 ## Limitations (for now)
 
@@ -371,4 +373,14 @@ def list_all_data_objects(rule_args, callback, rei):
 
 ### How do I embed single quotes within a string literal?
 
-To embed a single quote character within a string literal, write two adjacent single quotes. For example, `'What''s the current time?'`.
+To embed a single quote character within a string literal, write two adjacent single quotes.
+
+For example, `'John''s file.txt'`.
+
+### How do I embed a hexadecimal byte within a string literal?
+
+To embed a hexadecimal byte within a string literal, use `\xNN`, where **NN** is the hexadecimal value of the byte.
+
+For example, if the parser is passed `'Hello, GenQuery2\x21'`, it will expand the string to `'Hello, GenQuery2!'`. This happens before any SQL is executed.
+
+`\x` can only represent a single byte.

--- a/parser/dsl/lexer.l
+++ b/parser/dsl/lexer.l
@@ -2,6 +2,10 @@
     #include "irods/genquery2_driver.hpp"
 
     #include <fmt/format.h>
+
+    #include <charconv>
+    #include <cstdint>
+    #include <string>
 %}
 
 %option c++ warn nodefault noyywrap nounput noinput batch
@@ -36,8 +40,21 @@
 '                      { BEGIN(ss_string_literal); string_literal.clear(); }
 <ss_string_literal>{
     "''"               { string_literal += '\''; }
+    \\x[0-9A-Fa-f]{2}  {
+                            std::uint8_t value;
+                            const auto err = std::from_chars(YYText() + 2, YYText() + 4, value, 16);
+
+                            if (err.ec == std::errc::invalid_argument) {
+                                throw yy::parser::syntax_error{loc, fmt::format("invalid hex value: [{}]", YYText())};
+                            }
+                            else if (err.ec == std::errc::result_out_of_range) {
+                                throw yy::parser::syntax_error{loc, fmt::format("hex value cannot be represented: [{}]", YYText())};
+                            }
+
+                            string_literal.push_back(value);
+                       }
     '                  { BEGIN(INITIAL); return yy::parser::make_STRING_LITERAL(string_literal, loc); }
-    .                  { string_literal.append(1, *yytext); }
+    .                  { string_literal += YYText(); }
     <<EOF>>            { throw yy::parser::syntax_error{loc, fmt::format("missing closing single quote: [{}]", string_literal)}; }
 }
 [ \t\n]                ;

--- a/parser/dsl/lexer.l
+++ b/parser/dsl/lexer.l
@@ -19,7 +19,7 @@
 
 %{
     // Code run each time a pattern is matched.
-    #define YY_USER_ACTION loc.columns(yyleng);
+    #define YY_USER_ACTION loc.columns(YYLeng());
 %}
 
 %x ss_string_literal
@@ -99,10 +99,10 @@
 ","                    return yy::parser::make_COMMA(loc);
 "("                    return yy::parser::make_PAREN_OPEN(loc);
 ")"                    return yy::parser::make_PAREN_CLOSE(loc);
-[a-zA-Z][a-zA-Z0-9_]*  return yy::parser::make_IDENTIFIER(yytext, loc);
-[0-9]+                 return yy::parser::make_POSITIVE_INTEGER(yytext, loc);
--?[0-9]+               return yy::parser::make_INTEGER(yytext, loc);
-.                      throw yy::parser::syntax_error{loc, fmt::format("invalid character: {}", yytext)};
+[a-zA-Z][a-zA-Z0-9_]*  return yy::parser::make_IDENTIFIER(YYText(), loc);
+[0-9]+                 return yy::parser::make_POSITIVE_INTEGER(YYText(), loc);
+-?[0-9]+               return yy::parser::make_INTEGER(YYText(), loc);
+.                      throw yy::parser::syntax_error{loc, fmt::format("invalid character: {}", YYText())};
 <<EOF>>                return yy::parser::make_END_OF_INPUT(loc);
 
 %%


### PR DESCRIPTION
This PR allows users to embed bytes into the string literals using hex notation.

For example:
```
iquery "select DATA_NAME where DATA_NAME = '[]{}()#\x21%'"
```